### PR TITLE
Generate the image in admin for all is_staff Users

### DIFF
--- a/image/views.py
+++ b/image/views.py
@@ -21,7 +21,7 @@ IMAGE_WRONG_REQUEST = getattr(settings, 'IMAGE_WRONG_REQUEST', "Wrong request")
 def image(request, path, token, autogen=False):
 
     is_admin = False
-    if ("is_admin=true" in token and request and request.user.has_perm('admin')) or autogen:
+    if ("is_admin=true" in token and request and request.user.is_staff) or autogen:
         parameters = token
         is_admin = True
         if autogen:


### PR DESCRIPTION
In the actual code, as the permission "admin" is not created at syncdb, only the superusers can generate the images in the admin.
Using is_staff instead of this permission sounds doing the job.
Another solution could be to add the creation of the permission during syncdb.
(Or to create it manually, but well... ;) ).
Or maybe I'm missing something. ;)
